### PR TITLE
chore: increase cyclomatic complexity limit to `12`

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,6 +36,9 @@ linters:
     - wrapcheck
 
 linters-settings:
+  cyclop:
+    max-complexity: 12
+
   exhaustive:
     default-signifies-exhaustive: true
 

--- a/internal/godot/artifact/archive/tarxz.go
+++ b/internal/godot/artifact/archive/tarxz.go
@@ -39,7 +39,7 @@ func (a TarXZ[T]) Name() string {
 // NOTE: This method does not detect insecure filepaths included in the archive.
 // Instead, ensure the binary is compiled with the GODEBUG option
 // 'tarinsecurepath=0' (see https://github.com/golang/go/issues/55356).
-func (a TarXZ[T]) extract(ctx context.Context, path, out string) error { //nolint:cyclop
+func (a TarXZ[T]) extract(ctx context.Context, path, out string) error {
 	f, err := os.Open(path)
 	if err != nil {
 		return err

--- a/internal/godot/mirror/mirror.go
+++ b/internal/godot/mirror/mirror.go
@@ -50,7 +50,7 @@ type Mirror interface {
 
 // Choose selects the best 'Mirror' for downloading assets for the specified
 // version of Godot.
-func Choose(ctx context.Context, v version.Version) (Mirror, error) { //nolint:cyclop,funlen,ireturn
+func Choose(ctx context.Context, v version.Version) (Mirror, error) { //nolint:funlen,ireturn
 	eg, ctx := errgroup.WithContext(ctx)
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/internal/godot/platform/platform.go
+++ b/internal/godot/platform/platform.go
@@ -43,7 +43,7 @@ type Platform struct {
 // Parses a 'Platform' struct from a platform identifier. There are potentially
 // multiple valid identifiers for any given platform due to schema differences
 // across Godot versions.
-func Parse(input string) (Platform, error) { //nolint:cyclop
+func Parse(input string) (Platform, error) {
 	if input == "" {
 		return Platform{}, ErrMissingPlatform
 	}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -185,7 +185,7 @@ func ToolPath(store string, ex executable.Executable) (string, error) {
 /* --------------------------- Function: Versions --------------------------- */
 
 // Returns a list of cached Godot executables.
-func Executables(ctx context.Context, store string) ([]executable.Executable, error) { //nolint:cyclop
+func Executables(ctx context.Context, store string) ([]executable.Executable, error) {
 	store, err := Clean(store)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
See https://groups.google.com/g/golang-nuts/c/HNNUjE5VWos for a discussion on this. The old limit `10` felt a little limiting given Go's error handling.