### PR TITLE
refactor(internal/godot/mirror): split `Mirror` interface into separate concerns

### DIFF
--- a/internal/godot/mirror/mirror.go
+++ b/internal/godot/mirror/mirror.go
@@ -18,6 +18,7 @@ import (
 var (
 	ErrInvalidSpecification = errors.New("invalid specification")
 	ErrInvalidURL           = errors.New("invalid URL")
+	ErrMissingMirrors       = errors.New("no mirrors provided")
 	ErrNotFound             = errors.New("no mirror found")
 	ErrNotSupported         = errors.New("mirror not supported")
 )
@@ -79,6 +80,10 @@ func Select( //nolint:ireturn
 	p platform.Platform,
 	mirrors []Mirror,
 ) (Mirror, error) {
+	if len(mirrors) == 0 {
+		return nil, ErrMissingMirrors
+	}
+
 	eg, ctx := errgroup.WithContext(ctx)
 
 	ctx, cancel := context.WithCancel(ctx)

--- a/internal/godot/mirror/mirror_test.go
+++ b/internal/godot/mirror/mirror_test.go
@@ -3,7 +3,23 @@ package mirror
 import (
 	"net/url"
 	"testing"
+
+	"github.com/coffeebeats/gdenv/internal/godot/artifact/checksum"
+	"github.com/coffeebeats/gdenv/internal/godot/version"
 )
+
+/* ----------------------- Function: mustMakeNewSource ---------------------- */
+
+func mustMakeNewSource(t *testing.T, v version.Version) checksum.Source {
+	t.Helper()
+
+	s, err := checksum.NewSource(v)
+	if err != nil {
+		t.Fatalf("test setup: %#v", err)
+	}
+
+	return s
+}
 
 /* ------------------------- Function: mustParseURL ------------------------- */
 

--- a/internal/godot/mirror/mirror_test.go
+++ b/internal/godot/mirror/mirror_test.go
@@ -1,12 +1,123 @@
 package mirror
 
 import (
+	"context"
+	"errors"
 	"net/url"
 	"testing"
 
+	"github.com/coffeebeats/gdenv/internal/client"
 	"github.com/coffeebeats/gdenv/internal/godot/artifact/checksum"
+	"github.com/coffeebeats/gdenv/internal/godot/platform"
 	"github.com/coffeebeats/gdenv/internal/godot/version"
+	"github.com/go-resty/resty/v2"
+	"github.com/jarcoal/httpmock"
 )
+
+/* ------------------------------ Test: Select ------------------------------ */
+
+func TestSelect(t *testing.T) {
+	tests := []struct {
+		name    string
+		mirrors []Mirror
+		v       version.Version
+		p       platform.Platform
+		expects map[string]httpmock.Responder
+
+		want Mirror
+		err  error
+	}{
+		// Invalid inputs
+		{
+			name: "no mirrors results in an error",
+
+			err: ErrMissingMirrors,
+		},
+		{
+			name:    "no mirror supports version",
+			mirrors: []Mirror{TuxFamily{}, GitHub{}},
+			v:       version.Godot4(),
+			p:       platform.MustParse("win64"),
+			expects: map[string]httpmock.Responder{
+				"https://github.com/godotengine/godot/releases/download/4.0-stable/Godot_v4.0-stable_win64.exe.zip": httpmock.NewBytesResponder(400, nil),
+				"https://downloads.tuxfamily.org/godotengine/4.0/Godot_v4.0-stable_win64.exe.zip":                   httpmock.NewBytesResponder(400, nil),
+			},
+
+			err: ErrNotFound,
+		},
+
+		// Valid inputs
+		{
+			name:    "one valid mirror is selected",
+			mirrors: []Mirror{GitHub{}},
+			v:       version.Godot4(),
+			p:       platform.MustParse("win64"),
+			expects: map[string]httpmock.Responder{
+				"https://github.com/godotengine/godot/releases/download/4.0-stable/Godot_v4.0-stable_win64.exe.zip": httpmock.NewBytesResponder(200, nil),
+			},
+
+			want: GitHub{},
+		},
+		{
+			name:    "best mirror is selected",
+			mirrors: []Mirror{TuxFamily{}, GitHub{}},
+			v:       version.Godot4(),
+			p:       platform.MustParse("win64"),
+			expects: map[string]httpmock.Responder{
+				"https://github.com/godotengine/godot/releases/download/4.0-stable/Godot_v4.0-stable_win64.exe.zip": httpmock.NewBytesResponder(200, nil),
+				"https://downloads.tuxfamily.org/godotengine/4.0/Godot_v4.0-stable_win64.exe.zip":                   httpmock.NewBytesResponder(200, nil),
+			},
+
+			want: TuxFamily{}, // Appears first in 'mirrors'.
+		},
+		{
+			name:    "worse mirror is selected if best isn't available",
+			mirrors: []Mirror{GitHub{}, TuxFamily{}},
+			v:       version.Godot4(),
+			p:       platform.MustParse("win64"),
+			expects: map[string]httpmock.Responder{
+				"https://github.com/godotengine/godot/releases/download/4.0-stable/Godot_v4.0-stable_win64.exe.zip": httpmock.NewBytesResponder(400, nil),
+				"https://downloads.tuxfamily.org/godotengine/4.0/Godot_v4.0-stable_win64.exe.zip":                   httpmock.NewBytesResponder(200, nil),
+			},
+
+			want: TuxFamily{}, // Only mirror with successful response.
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Given: A new 'Client' instance without retries.
+			c := client.New()
+
+			// Given: Retry behavior is disabled for the client.
+			c.RestyClient().SetRetryCount(0)
+
+			// Given: The 'Client' instance is assigned a mock environment.
+			httpmock.ActivateNonDefault(c.RestyClient().GetClient())
+			defer httpmock.DeactivateAndReset()
+
+			for urlRaw, responder := range tc.expects {
+				httpmock.RegisterResponder(resty.MethodHead, urlRaw, responder)
+			}
+
+			// Given: A 'context.Context' with the stubbed client injected.
+			ctx := context.WithValue(context.Background(), clientKey{}, c)
+
+			// When: A 'Mirror' is selected from the list of options.
+			got, err := Select(ctx, tc.v, tc.p, tc.mirrors)
+
+			// Then: The resulting error matches expectations.
+			if !errors.Is(err, tc.err) {
+				t.Errorf("err: got %v, want %v", err, tc.err)
+			}
+
+			// Then: The resulting 'Mirror' matches the expected value.
+			if got != tc.want {
+				t.Errorf("output: got %T, want %T", got, tc.want)
+			}
+		})
+	}
+}
 
 /* ----------------------- Function: mustMakeNewSource ---------------------- */
 

--- a/internal/godot/mirror/tuxfamily.go
+++ b/internal/godot/mirror/tuxfamily.go
@@ -37,27 +37,30 @@ var (
 /* -------------------------------------------------------------------------- */
 
 // A mirror implementation for fetching artifacts via the Godot TuxFamily host.
-type TuxFamily struct {
-	client client.Client
-}
+type TuxFamily struct{}
 
-// Validate at compile-time that 'TuxFamily' implements 'Mirror'.
-var _ Mirror = &TuxFamily{} //nolint:exhaustruct
-
-/* ------------------------------ Function: New ----------------------------- */
-
-func NewTuxFamily() TuxFamily {
-	c := client.NewWithRedirectDomains(tuxfamilyDownloadsDomain)
-
-	return TuxFamily{c}
-}
+// Validate at compile-time that 'TuxFamily' implements 'Mirror' interfaces.
+var _ Mirror = &TuxFamily{}
+var _ Executable = &TuxFamily{}
+var _ Source = &TuxFamily{}
 
 /* ------------------------------ Impl: Mirror ------------------------------ */
 
 // Returns a new 'client.Client' for downloading artifacts from the mirror.
-func (m TuxFamily) Client() client.Client {
-	return m.client
+func (m TuxFamily) Domains() []string {
+	return nil
 }
+
+// Checks whether the version is broadly supported by the mirror. No network
+// request is issued, but this does not guarantee the host has the version.
+// To check whether the host has the version definitively via the network,
+// use the 'checkIfExists' method.
+func (m TuxFamily) Supports(v version.Version) bool {
+	// TuxFamily seems to contain all published releases.
+	return v.CompareNormal(versionTuxFamilyMinSupported) >= 0
+}
+
+/* ---------------------------- Impl: Executable ---------------------------- */
 
 func (m TuxFamily) ExecutableArchive(
 	v version.Version,
@@ -113,6 +116,8 @@ func (m TuxFamily) ExecutableArchiveChecksums(v version.Version) (artifact.Remot
 	return a, nil
 }
 
+/* ------------------------------ Impl: Source ------------------------------ */
+
 func (m TuxFamily) SourceArchive(v version.Version) (artifact.Remote[source.Archive], error) {
 	var a artifact.Remote[source.Archive]
 
@@ -163,15 +168,6 @@ func (m TuxFamily) SourceArchiveChecksums(v version.Version) (artifact.Remote[ch
 	a.Artifact, a.URL = checksumsSource, urlParsed
 
 	return a, nil
-}
-
-// Checks whether the version is broadly supported by the mirror. No network
-// request is issued, but this does not guarantee the host has the version.
-// To check whether the host has the version definitively via the network,
-// use the 'checkIfExists' method.
-func (m TuxFamily) Supports(v version.Version) bool {
-	// TuxFamily seems to contain all published releases.
-	return v.CompareNormal(versionTuxFamilyMinSupported) >= 0
 }
 
 /* -------------------- Function: urlTuxFamilyVersionDir -------------------- */

--- a/internal/godot/mirror/tuxfamily_test.go
+++ b/internal/godot/mirror/tuxfamily_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/coffeebeats/gdenv/internal/godot/artifact"
 	"github.com/coffeebeats/gdenv/internal/godot/artifact/checksum"
 	"github.com/coffeebeats/gdenv/internal/godot/artifact/executable"
+	"github.com/coffeebeats/gdenv/internal/godot/artifact/source"
 	"github.com/coffeebeats/gdenv/internal/godot/version"
 )
 
@@ -109,6 +110,86 @@ func TestTuxFamilyExecutableArchiveChecksums(t *testing.T) {
 			want := artifact.Remote[checksum.Executable]{Artifact: ex, URL: tc.url}
 			if !reflect.DeepEqual(got, want) {
 				t.Errorf("output: got %#v, want %#v", got, want)
+			}
+		})
+	}
+}
+
+/* ---------------------- Test: TuxFamily.SourceArchive --------------------- */
+
+func TestTuxFamilySourceArchive(t *testing.T) {
+	tests := []struct {
+		v version.Version
+
+		artifact source.Archive
+		url      *url.URL
+		err      error
+	}{
+		// Invalid inputs
+		{v: version.Version{}, err: ErrInvalidSpecification},
+		{v: version.MustParse("v0.1.0"), err: ErrInvalidSpecification},
+
+		// Valid inputs
+		{
+			v:        version.MustParse("v4.1.1"),
+			artifact: source.Archive{Artifact: source.New(version.MustParse("v4.1.1"))},
+			url:      mustParseURL(t, "https://downloads.tuxfamily.org/godotengine/4.1.1/godot-4.1.1-stable.tar.xz"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.v.String(), func(t *testing.T) {
+			remote, err := (&TuxFamily{}).SourceArchive(tc.v)
+
+			if !errors.Is(err, tc.err) {
+				t.Errorf("err: got %v, want %v", err, tc.err)
+			}
+
+			if got := remote.Artifact; !reflect.DeepEqual(got, tc.artifact) {
+				t.Errorf("output: got %v, want %v", got, tc.artifact)
+			}
+			if got := remote.URL; !reflect.DeepEqual(got, tc.url) {
+				t.Errorf("output: got %v, want %v", got, tc.url)
+			}
+		})
+	}
+}
+
+/* ----------------- Test: TuxFamily.SourceArchiveChecksums ----------------- */
+
+func TestTuxFamilySourceArchiveChecksums(t *testing.T) {
+	tests := []struct {
+		v version.Version
+
+		artifact checksum.Source
+		url      *url.URL
+		err      error
+	}{
+		// Invalid inputs
+		{v: version.Version{}, err: ErrInvalidSpecification},
+		{v: version.MustParse("v0.1.0"), err: ErrInvalidSpecification},
+
+		// Valid inputs
+		{
+			v:        version.MustParse("v4.1.1"),
+			artifact: mustMakeNewSource(t, version.MustParse("v4.1.1")),
+			url:      mustParseURL(t, "https://downloads.tuxfamily.org/godotengine/4.1.1/godot-4.1.1-stable.tar.xz.sha256"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.v.String(), func(t *testing.T) {
+			remote, err := (&TuxFamily{}).SourceArchiveChecksums(tc.v)
+
+			if !errors.Is(err, tc.err) {
+				t.Errorf("err: got %v, want %v", err, tc.err)
+			}
+
+			if got := remote.Artifact; !reflect.DeepEqual(got, tc.artifact) {
+				t.Errorf("output: got %v, want %v", got, tc.artifact)
+			}
+			if got := remote.URL; !reflect.DeepEqual(got, tc.url) {
+				t.Errorf("output: got %v, want %v", got, tc.url)
 			}
 		})
 	}

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -38,7 +38,7 @@ func checkIsDirectory(path string) error {
 // reporter extracted from the context using the provided key.
 func downloadArtifact[T artifact.Artifact](
 	ctx context.Context,
-	c client.Client,
+	c *client.Client,
 	a artifact.Remote[T],
 	out string,
 	progressKey any,

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/coffeebeats/gdenv/internal/client"
 	"github.com/coffeebeats/gdenv/internal/godot/artifact"
-	"github.com/coffeebeats/gdenv/internal/godot/mirror"
 	"github.com/coffeebeats/gdenv/internal/progress"
 )
 
@@ -39,7 +38,7 @@ func checkIsDirectory(path string) error {
 // reporter extracted from the context using the provided key.
 func downloadArtifact[T artifact.Artifact](
 	ctx context.Context,
-	m mirror.Mirror,
+	c client.Client,
 	a artifact.Remote[T],
 	out string,
 	progressKey any,
@@ -49,5 +48,5 @@ func downloadArtifact[T artifact.Artifact](
 		ctx = client.WithProgress(ctx, p)
 	}
 
-	return m.Client().DownloadTo(ctx, a.URL, out)
+	return c.DownloadTo(ctx, a.URL, out)
 }

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -24,7 +24,7 @@ import (
 
 // Downloads and caches a platform-specific version of Godot.
 func Executable(ctx context.Context, storePath string, ex executable.Executable) error {
-	m, err := mirror.Choose(ctx, ex.Version(), ex.Platform())
+	m, err := mirror.Select(ctx, ex.Version(), ex.Platform(), availableMirrors())
 	if err != nil {
 		return err
 	}
@@ -84,7 +84,7 @@ func Source(ctx context.Context, storePath string, src source.Source) error {
 	// arbitrary artifact. For now, select a platform that will certainly exist.
 	p := platform.Platform{Arch: platform.Amd64, OS: platform.Windows}
 
-	m, err := mirror.Choose(ctx, src.Version(), p)
+	m, err := mirror.Select(ctx, src.Version(), p, availableMirrors())
 	if err != nil {
 		return err
 	}
@@ -114,4 +114,12 @@ func Source(ctx context.Context, storePath string, src source.Source) error {
 			Path:     localSourceArchive.Path,
 		},
 	)
+}
+
+/* ----------------------- Function: availableMirrors ----------------------- */
+
+// availableMirrors returns the list of possible 'Mirror' hosts to use for
+// downloads.
+func availableMirrors() []mirror.Mirror {
+	return []mirror.Mirror{mirror.GitHub{}, mirror.TuxFamily{}}
 }


### PR DESCRIPTION
This PR also decouples `client.Client` from `mirror.Mirror`. This will enable making `mirror` interfaces public.